### PR TITLE
Moved MIT license to the About category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,6 +1,9 @@
 module.exports = {
   docs: {
-    'Getting Started': ['overview', 'license', 'installing-server'],
+    'Getting Started': [
+      'overview',
+      'installing-server'
+    ],
     'Use Cases': [
       'use-cases-orchestration',
       'use-cases-distributed-transactions',
@@ -11,7 +14,7 @@ module.exports = {
       'use-cases-dsl',
       'use-cases-actors',
     ],
-    Learn: [
+    'Learn': [
       'learn-glossary',
       'learn-workflows',
       'learn-activities',
@@ -58,6 +61,7 @@ module.exports = {
     ],
     'About': [
       'docs-sla',
+      'license',
     ],
   },
 };


### PR DESCRIPTION
The MIT license does not need really pertain to the "Getting Started" category. Moving it to the "About" category of the docs.