### PR TITLE
Changed site URL to docs.temporal.io for SEO purposes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,11 +3,11 @@ const versions = require('./versions.json');
 module.exports = {
   title: 'Temporal',
   tagline: 'Invincible applications, invisible infrastructure',
-  url: 'https://temporalio.github.io',
+  url: 'https://docs.temporal.io',
   baseUrl: '/',
   favicon: 'img/favicon.svg',
   organizationName: 'temporalio', // Usually your GitHub org/user name.
-  projectName: 'temporal-documentation-legacy-v2', // Usually your repo name.
+  projectName: 'Temporal Documentation', // Usually your repo name.
   plugins: [
     '@docusaurus/plugin-google-gtag',
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   baseUrl: '/',
   favicon: 'img/favicon.svg',
   organizationName: 'temporalio', // Usually your GitHub org/user name.
-  projectName: 'Temporal Documentation', // Usually your repo name.
+  projectName: 'temporal-documentation-legacy-v2', // Usually your repo name.
   plugins: [
     '@docusaurus/plugin-google-gtag',
     [


### PR DESCRIPTION
There is an SEO issue caused by the site config -
![Screen Shot 2020-07-17 at 2 37 15 PM](https://user-images.githubusercontent.com/34380806/87828864-22c23500-c83b-11ea-9836-aa68af9fac62.png)