### PR TITLE
Go SDK docs: code samples import path rename

### DIFF
--- a/docs/filter-workflows.md
+++ b/docs/filter-workflows.md
@@ -5,7 +5,7 @@ title: Filter Workflows
 
 Temporal supports creating workflows with customized key-value pairs, updating the information within the workflow code, and then listing/searching workflows with a SQL-like query. For example, you can create workflows with keys `city` and `age`, then search all workflows with `city = seattle and age > 22`.
 
-Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/temporal/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)):
+Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)):
 
 ```sql
 WorkflowType = "main.Workflow" and Status != 0 and (StartTime > "2019-06-07T16:46:34-08:00" or CloseTime > "2019-06-07T16:46:34-08:00" order by StartTime desc)
@@ -15,7 +15,7 @@ WorkflowType = "main.Workflow" and Status != 0 and (StartTime > "2019-06-07T16:4
 
 Temporal offers two methods for creating workflows with key-value pairs: memo and search attributes. Memo can only be provided on workflow start. Also, memo data are not indexed, and are therefore not searchable. Memo data are visible when listing workflows using the list APIs. Search attributes data are indexed so you can search workflows by querying on these attributes. However, search attributes require the use of Elasticsearch.
 
-Memo and search attributes are available in the Go client in [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#StartWorkflowOptions).
+Memo and search attributes are available in the Go client in [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions).
 
 ```go
 type StartWorkflowOptions struct {
@@ -41,7 +41,7 @@ Some important distinctions between memo and search attributes:
 
 ## Search Attributes (Go Client Usage)
 
-When using the Temporal Go client, provide key-value pairs as SearchAttributes in [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#StartWorkflowOptions).
+When using the Temporal Go client, provide key-value pairs as SearchAttributes in [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions).
 
 SearchAttributes is `map[string]interface{}` where the keys need to be allowlisted so that Temporal knows the attribute key name and value type. The value provided in the map must be the same type as registered.
 
@@ -79,7 +79,7 @@ Use the admin CLI to add a new search attribute:
 tctl --namespace samples-namespace adm cl asa --search_attr_key NewKey --search_attr_type string
 ```
 
-The possible values for **_search_attr_type_** are: 
+The possible values for **_search_attr_type_** are:
 
 * string
 * keyword
@@ -133,7 +133,7 @@ Temporal reserves keys like NamespaceId, WorkflowId, and RunId. These can only b
 
 ### Upsert Search Attributes in Workflow
 
-[UpsertSearchAttributes](https://pkg.go.dev/go.temporal.io/temporal/workflow#UpsertSearchAttributes) is used to add or update search attributes from within the workflow code.
+[UpsertSearchAttributes](https://pkg.go.dev/go.temporal.io/sdk/workflow#UpsertSearchAttributes) is used to add or update search attributes from within the workflow code.
 
 Go samples for search attributes can be found at [github.com/temporalio/temporal-go-samples](https://github.com/temporalio/temporal-go-samples/tree/master/searchattributes).
 
@@ -176,7 +176,7 @@ When performing a [ContinueAsNew](/docs/go-continue-as-new) or using [Cron](/doc
 
 ## Query Capabilities
 
-Query workflows by using a SQL-like where clause when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/temporal/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)).
+Query workflows by using a SQL-like where clause when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)).
 
 Note that you will only see workflows from one namespace when querying.
 

--- a/docs/filter-workflows.md
+++ b/docs/filter-workflows.md
@@ -5,7 +5,7 @@ title: Filter Workflows
 
 Temporal supports creating workflows with customized key-value pairs, updating the information within the workflow code, and then listing/searching workflows with a SQL-like query. For example, you can create workflows with keys `city` and `age`, then search all workflows with `city = seattle and age > 22`.
 
-Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)):
+Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/learn-cli#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client))
 
 ```sql
 WorkflowType = "main.Workflow" and Status != 0 and (StartTime > "2019-06-07T16:46:34-08:00" or CloseTime > "2019-06-07T16:46:34-08:00" order by StartTime desc)
@@ -31,7 +31,7 @@ type StartWorkflowOptions struct {
 }
 ```
 
-In the Java client, the _WorkflowOptions.Builder_ has similar methods for [memo](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/client/WorkflowOptions.Builder.html#setMemo-java.util.Map-) and [search attributes](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/client/WorkflowOptions.Builder.html#setSearchAttributes-java.util.Map-).
+In the Java client, the _WorkflowOptions.Builder_ has similar methods for [memo](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setMemo-java.util.Map-) and [search attributes](https://www.javadoc.io/doc/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/client/WorkflowOptions.Builder.html#setSearchAttributes-java.util.Map-).
 
 Some important distinctions between memo and search attributes:
 

--- a/docs/go-activities.md
+++ b/docs/go-activities.md
@@ -33,7 +33,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"go.temporal.io/temporal/activity"
+	"go.temporal.io/sdk/activity"
 )
 
 // SimpleActivity is a sample Temporal activity function that takes one parameter and

--- a/docs/go-create-workflows.md
+++ b/docs/go-create-workflows.md
@@ -29,7 +29,7 @@ package sample
 import (
 	"time"
 
-	"go.temporal.io/temporal/workflow"
+	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 )
 

--- a/docs/go-distributed-cron.md
+++ b/docs/go-distributed-cron.md
@@ -6,7 +6,7 @@ title: Distributed CRON
 It is relatively straightforward to turn any Temporal workflow into a Cron workflow. All you need
 is to supply a cron schedule when starting the workflow using the CronSchedule
 parameter of
-[StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#StartWorkflowOptions).
+[StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions).
 
 You can also start a workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument.
 

--- a/docs/go-quick-start.md
+++ b/docs/go-quick-start.md
@@ -33,9 +33,9 @@ go: creating new go.mod: module github.com/temporalio/tutorial-go-sdk
 Add dependency to Temporal Go SDK
 
 ```bash
-> go get go.temporal.io/temporal@v0.26.0
-go: downloading go.temporal.io/temporal v0.26.0
-go: go.temporal.io/temporal upgrade => v0.26.0
+> go get go.temporal.io/sdk@latest
+go: downloading go.temporal.io/sdk v0.28.0
+go: go.temporal.io/sdk upgrade => v0.28.0
 ```
 
 ## Implement Activities
@@ -50,7 +50,7 @@ package main
 import (
 	"context"
 
-	"go.temporal.io/temporal/activity"
+	"go.temporal.io/sdk/activity"
 )
 
 // GetUser is the implementation for Temporal activity
@@ -72,7 +72,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.temporal.io/temporal/activity"
+	"go.temporal.io/sdk/activity"
 )
 
 // SendGreeting is the implementation for Temporal activity
@@ -95,7 +95,7 @@ package main
 import (
 	"time"
 
-	"go.temporal.io/temporal/workflow"
+	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 )
 
@@ -136,8 +136,8 @@ package main
 import (
 	"go.uber.org/zap"
 
-	"go.temporal.io/temporal/client"
-	"go.temporal.io/temporal/worker"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
 )
 
 func main() {

--- a/docs/go-sdk-video-tutorial.md
+++ b/docs/go-sdk-video-tutorial.md
@@ -16,7 +16,7 @@ package activities
 import (
 	"context"
 
-	"go.temporal.io/temporal/activity"
+	"go.temporal.io/sdk/activity"
 )
 
 // GetUser is the implementation for Temporal activity
@@ -34,7 +34,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.temporal.io/temporal/activity"
+	"go.temporal.io/sdk/activity"
 )
 
 // SendGreeting is the implementation for Temporal activity
@@ -54,7 +54,7 @@ import (
 	"time"
 
 	"github.com/samarabbas/tutorial-go-sdk/activities"
-	"go.temporal.io/temporal/workflow"
+	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
 )
 
@@ -95,8 +95,8 @@ import (
 	"github.com/samarabbas/tutorial-go-sdk/activities"
 	"github.com/samarabbas/tutorial-go-sdk/workflows"
 
-	"go.temporal.io/temporal/client"
-	"go.temporal.io/temporal/worker"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
 )
 
 func main() {

--- a/docs/go-signals.md
+++ b/docs/go-signals.md
@@ -46,8 +46,8 @@ channel and process the payload received with the signal.
 ## SignalWithStart
 
 You may not know if a workflow is running and can accept a signal. The
-[client.SignalWithStartWorkflow](https://pkg.go.dev/go.temporal.io/temporal/client#Client) API
-[client.SignalWithStartWorkflow](https://pkg.go.dev/go.temporal.io/temporal/client#Client) API
+[client.SignalWithStartWorkflow](https://pkg.go.dev/go.temporal.io/sdk/client#Client) API
+[client.SignalWithStartWorkflow](https://pkg.go.dev/go.temporal.io/sdk/client#Client) API
 allows you to send a signal to the current workflow instance if one exists or to create a new
-run and then send the signal. `SignalWithStartWorkflow` therefore doesn't take a run Id as a 
+run and then send the signal. `SignalWithStartWorkflow` therefore doesn't take a run Id as a
 parameter.

--- a/docs/go-tracing.md
+++ b/docs/go-tracing.md
@@ -7,8 +7,8 @@ title: Tracing and Context Propagation
 
 The Go client provides distributed tracing support through [OpenTracing](https://opentracing.io/). Tracing can be
 configured by providing an [opentracing.Tracer](https://pkg.go.dev/github.com/opentracing/opentracing-go#Tracer)
-implementation in [ClientOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#ClientOptions)
-and [WorkerOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#WorkerOptions) during client and worker instantiation,
+implementation in [ClientOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#ClientOptions)
+and [WorkerOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#WorkerOptions) during client and worker instantiation,
 respectively. Tracing allows
 you to view the call graph of a workflow along with its activities, child workflows etc. For more details on how to
 configure and leverage tracing, see the [OpenTracing documentation](https://opentracing.io/docs/getting-started/).
@@ -19,7 +19,7 @@ propagation support provided by the client.
 ## Context Propagation
 
 We provide a standard way to propagate custom context across a workflow.
-[ClientOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#ClientOptions) and [WorkerOptions](https://pkg.go.dev/go.temporal.io/temporal/internal#WorkerOptions)
+[ClientOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#ClientOptions) and [WorkerOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#WorkerOptions)
 allow configuring a context propagator. The context propagator extracts and passes on information present in the `context.Context`
 and `workflow.Context` objects across the workflow. Once a context propagator is configured, you should be able to access the required values
 in the context objects as you would normally do in Go.
@@ -36,8 +36,8 @@ message Header {
 }
 ```
 
-The client leverages this to pass around selected context information. [HeaderReader](https://pkg.go.dev/go.temporal.io/temporal/internal#HeaderReader)
-and [HeaderWriter](https://pkg.go.dev/go.temporal.io/temporal/internal#HeaderWriter) are interfaces
+The client leverages this to pass around selected context information. [HeaderReader](https://pkg.go.dev/go.temporal.io/sdk/internal#HeaderReader)
+and [HeaderWriter](https://pkg.go.dev/go.temporal.io/sdk/internal#HeaderWriter) are interfaces
 that allow reading and writing to the Temporal server headers. The client already provides [implementations](https://github.com/temporalio/temporal-go-sdk/blob/master/internal/headers.go)
 for these. `HeaderWriter` sets a field in the header. Headers is a map, so setting a value for the the same key
 multiple times will overwrite the previous values. `HeaderReader` iterates through the headers map and runs the
@@ -58,10 +58,10 @@ type HeaderReader interface {
 Context propagators require implementing the following four methods to propagate selected context across a workflow:
 
 - `Inject` is meant to pick out the context keys of interest from a Go [context.Context](https://golang.org/pkg/context/#Context) object and write that into the
-headers using the [HeaderWriter](https://pkg.go.dev/go.temporal.io/temporal/internal#HeaderWriter) interface
-- `InjectFromWorkflow` is the same as above, but operates on a [workflow.Context](https://pkg.go.dev/go.temporal.io/temporal/internal#Context) object
+headers using the [HeaderWriter](https://pkg.go.dev/go.temporal.io/sdk/internal#HeaderWriter) interface
+- `InjectFromWorkflow` is the same as above, but operates on a [workflow.Context](https://pkg.go.dev/go.temporal.io/sdk/internal#Context) object
 - `Extract` reads the headers and places the information of interest back into the [context.Context](https://golang.org/pkg/context/#Context) object
-- `ExtractToWorkflow` is the same as above, but operates on a [workflow.Context](https://pkg.go.dev/go.temporal.io/temporal/internal#Context) object
+- `ExtractToWorkflow` is the same as above, but operates on a [workflow.Context](https://pkg.go.dev/go.temporal.io/sdk/internal#Context) object
 
 The [tracing context propagator](https://github.com/temporalio/temporal-go-sdk/blob/master/internal/tracer.go)
 shows a sample implementation of context propagation.

--- a/docs/go-workers.md
+++ b/docs/go-workers.md
@@ -17,9 +17,9 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
-	"go.temporal.io/temporal/client"
-	"go.temporal.io/temporal/worker"
-	"go.temporal.io/temporal/workflow"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 )
 
 var (

--- a/docs/go-workflow-testing.md
+++ b/docs/go-workflow-testing.md
@@ -18,8 +18,8 @@ import (
         "github.com/stretchr/testify/mock"
         "github.com/stretchr/testify/suite"
 
-        "go.temporal.io/temporal/activity"
-        "go.temporal.io/temporal/testsuite"
+        "go.temporal.io/sdk/activity"
+        "go.temporal.io/sdk/testsuite"
 )
 
 type UnitTestSuite struct {


### PR DESCRIPTION
Code samples were referencing `go.temporal.io/temporal` - updating them to `go.temporal.io/sdk`